### PR TITLE
Update to electrs v0.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=v0.9.4
+ARG VERSION=v0.9.5
 
 FROM rust:1.48.0-slim AS builder
 


### PR DESCRIPTION
https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#095-feb-4-2022

Release Notes
0.9.5 (Feb 4 2022)
Update dependencies (serde-json, serde, tempfile, crossbeam-channel)
Fix txid index collision handling (#653)
Use bitcoincore_rpc's getblockchaininfo implementation (#656)