### PR TITLE
Bump to v0.9.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=v0.9.9
+ARG VERSION=v0.9.10
 
 FROM rust:1.48.0-slim AS builder
 


### PR DESCRIPTION
- https://github.com/romanz/electrs/releases/tag/v0.9.10
- Release Notes: https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0910-nov-3-2022